### PR TITLE
fix: :bug: remove duplicate icons from navigation bar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,13 +10,6 @@ website:
       - href: calendar.qmd
       - href: seminars.qmd
       - href: network.qmd
-    tools:
-      - icon: github
-        href: "https://github.com/steno-aarhus/"
-      - icon: twitter
-        href: "https://twitter.com/StenoAarhusRes"
-      - icon: globe
-        href: directory.qmd
 
 format: sdca-theme-html
 


### PR DESCRIPTION
When I did #12 , I noticed that you have some duplicate icons in your navigation bar (top bar of the website). 

This PR removes those duplicates. 